### PR TITLE
修复更新分类报错

### DIFF
--- a/src/main/java/com/tale/service/MetasService.java
+++ b/src/main/java/com/tale/service/MetasService.java
@@ -172,8 +172,8 @@ public class MetasService {
             } else {
                 if (null != mid) {
                     metas = new Metas();
-                    metas.setMid(mid);
                     metas.setName(name);
+                    metas.where(Metas::getMid, mid);
                     metas.update();
                 } else {
                     metas = new Metas();


### PR DESCRIPTION
源mid字段作为更新的一部分，修复后mid要作为条件查询